### PR TITLE
removed the windows sections from plugin.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cordova-plugin-sip
 <h2>Fork of SIP plugin for Cordova & Phonegap Apps (IOS and Android)</h2>
-<h4>With my fork - Added Typescript Wrapper functionality</h4>
+<h4>With my fork - Added Typescript Wrapper functionality, removed windows from plugin.xml</h4>
 
 <h3>IOS</h3>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -10,7 +10,6 @@
   <engines>
     <engine name="cordova-android" version=">=4.0.0-dev" />
     <engine name="cordova-ios" version=">=4.0.0-dev" />
-    <engine name="cordova-wp8" version=">=4.0.0-dev" />
   </engines>
 
   <!-- android -->
@@ -148,7 +147,6 @@
 
     <source-file src="src/ios/libs/apple-darwin/share/" />
 
-
     <framework src="AVFoundation.framework" />
     <framework src="AudioToolbox.framework" />
     <framework src="CoreFoundation.framework" />
@@ -169,16 +167,5 @@
     </js-module>
 
 
-  </platform>
-
-  <!-- wp8 -->
-  <platform name="wp8">
-    <config-file target="config.xml" parent="/*">
-      <feature name="Linphone">
-        <param name="wp-package" value="Linphone"/>
-      </feature>
-    </config-file>
-
-    <source-file src="src/wp/Linphone.cs" />
   </platform>
 </plugin>


### PR DESCRIPTION
They were preventing platform from being added successfully.  There was just a "warn" printed after re adding the platform.  What it really meant was, we didn't install this plugin, because the xml had some windows garbage that is no longer supported.  Good luck buddy.