### PR TITLE
Included accept call and terminate call

### DIFF
--- a/src/android/src/Linphone.java
+++ b/src/android/src/Linphone.java
@@ -63,7 +63,10 @@ public class Linphone extends CordovaPlugin  {
                 return true;
             }
             else if(action.equals("acceptCall")){
-                acceptCall(args.getString(0), callbackContext);
+                acceptCall(callbackContext);
+                return true;
+            }else if(action.equals("terminateCall")){
+                terminateCall(callbackContext);
                 return true;
             }else if (action.equals("videocall")) {
                 videocall(args.getString(0), args.getString(1), callbackContext);
@@ -138,11 +141,12 @@ public class Linphone extends CordovaPlugin  {
         mLinphoneManager.listenCall(callbackContext);
     }
 
-    public static synchronized void acceptCall( final String isAcceptCall, final CallbackContext callbackContext){
-        if(isAcceptCall == "true")
-            mLinphoneManager.acceptCall(callbackContext);
-        else
-            mLinphoneManager.terminateCall();
+    public static synchronized void acceptCall(final CallbackContext callbackContext){
+        mLinphoneManager.acceptCall(callbackContext);
+    }
+
+    public static synchronized void terminateCall(final Callbackcontext callbackContext){
+        mLinphoneManager.terminateCall();
     }
 
     public static synchronized void videocall(final String address, final String displayName, final CallbackContext callbackContext) {

--- a/src/android/src/LinphoneMiniManager.java
+++ b/src/android/src/LinphoneMiniManager.java
@@ -503,6 +503,11 @@ public class LinphoneMiniManager implements LinphoneCoreListener {
 
 			LinphoneCoreFactory lcFactory = LinphoneCoreFactory.instance();
 
+			// Remove all proxy configs before login.  Persistent configs seem to cause android crash if logout hasn't cleaned them up.
+			LinphoneProxyConfig[] prxCfgs = mLinphoneCore.getProxyConfigList();
+			for (LinphoneProxyConfig prxCfg : prxCfgs) {
+				mLinphoneCore.removeProxyConfig(prxCfg);
+			}
 
 			LinphoneAddress address = lcFactory.createLinphoneAddress("sip:" + username + "@" + domain);
 			username = address.getUserName();

--- a/www/cordova-plugins-sip.js
+++ b/www/cordova-plugins-sip.js
@@ -18,13 +18,22 @@ module.exports =
             []
         );
     },
-    accept: function (value, successCallback, errorCallback) {
+    accept: function (successCallback, errorCallback) {
         cordova.exec(
             successCallback,
             errorCallback,
             "Linphone",
             "acceptCall",
-            [value]
+            []
+        );
+    },
+    terminate: function (successCallback, errorCallback) {
+        cordova.exec(
+            successCallback,
+            errorCallback,
+            "Linphone",
+            "terminateCall",
+            []
         );
     },
     listenCall: function (successCallback, errorCallback) {

--- a/www/wrapper.ts
+++ b/www/wrapper.ts
@@ -23,4 +23,10 @@ export class Linphone extends IonicNativePlugin {
 
     @Cordova()
     listenCall(): Promise<any> { return; }
+
+    @Cordova()
+    accept(): Promise<any> { return; }
+
+    @Cordova()
+    terminate(): Promise<any> { return; }
 }


### PR DESCRIPTION
Looking to add incoming call functionality through the cordova plugin.  Noticed accept call was requiring a parameter that either accepted or terminated the call, and decided to separate the two out for better readability and organization.